### PR TITLE
Update Safari support for font-variant-caps

### DIFF
--- a/css/properties/font-variant-caps.json
+++ b/css/properties/font-variant-caps.json
@@ -57,10 +57,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "9.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "6.0"


### PR DESCRIPTION
# Summary
Safari has supported `font-variant-caps` for around 6 years. I updated the compatibility table accordingly.
This is my first time updating a browser support compatibility table, so I'd appreciate someone double-checking my findings.

# Data
This patch: https://trac.webkit.org/changeset/190192/webkit/trunk/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
seems to be when these properties were added to WebKit:

- font-variant-ligatures
- font-variant-position
- font-variant-caps
- font-variant-numeric
- font-variant-alternates
- font-variant-east-asian


Per https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Configurations/Version.xcconfig?rev=190192 it appears that this is from webkit version 602.1.5.0.

According to the release notes, Mac Safari 9.1 added `font-variant-caps`: https://developer.apple.com/library/archive/releasenotes/General/WhatsNewInSafari/Articles/Safari_9_1.html#//apple_ref/doc/uid/TP40014305-CH10-SW1

Wikipedia's Safari version table (https://en.wikipedia.org/wiki/Safari_version_history#Safari_9) claims that Mac Safari 9.1 corresponds to webkit version 601.5.17 and iOS Safari 10 corresponds to WebKit versions 602.1.38 - 603.2.4. Note that the patch webkit version seems to be newer than the ones in the version table.

However, https://trac.webkit.org/browser/webkit/tags/Safari-601.5.7/Source/WebCore/css/CSSComputedStyleDeclaration.cpp?rev=194199 from Webkit version 601.5.7 does include the changes, as does https://trac.webkit.org/browser/webkit/tags/Safari-602.1.38/Source/WebCore/css/CSSComputedStyleDeclaration.cpp?rev=202385. Therefore, I'm reasonably confident in the versions I included in the PR.

# Related
https://github.com/mdn/browser-compat-data/issues/6070